### PR TITLE
docs: update README to reflect Linux support on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 - **Support for macOS and Linux?**
   - **macOS**: ❌ No. Due to potential inaccuracies caused by Hackintosh modifications, we cannot guarantee accurate information.
-  - **Linux**: 🔄 Work in progress in branch [add-linux-support](https://github.com/lzhoang2801/Hardware-Sniffer/tree/add-linux-support)
+  - **Linux**: ✅ Yes. Supported on `main` since the Linux platform implementation was merged. Hardware details are collected from the Linux kernel (`/sys`), and the resulting report and ACPI dump are fully compatible with OpCore Simplify.
 
 ## 🚀 **How To Use**
 
@@ -73,6 +73,18 @@
 5. **Results**: Your output will be saved in the `Results` folder in the program's directory.
 
    ![Results](https://i.imgur.com/gxV4aLL.png)
+
+6. **Linux**: Run the CLI with Python. The export and ACPI dump are done automatically:
+
+   ```bash
+   python3 Hardware-Sniffer-CLI.py -e
+   ```
+
+   By default the report is saved to `SysReport/Report.json` and the ACPI tables to `SysReport/ACPI/`. Use `-o <dir>` to change the output directory. The GUI version is also available:
+
+   ```bash
+   python3 HardwareSniffer.py
+   ```
 
 ## 🤝 **Contributing**
 


### PR DESCRIPTION
## Summary

The README Q&A section still claims Linux support is only "Work in progress" in the `add-linux-support` branch, but the Linux platform implementation (`Scripts/platforms/linux.py`) is already merged into `main` and works end-to-end (see #54).

## Changes

- **Q&A**: Mark Linux as supported on `main`, with a short note that data is collected via the Linux kernel (`/sys`).
- **How To Use**: Add a Linux section documenting the CLI usage:

  ```bash
  python3 Hardware-Sniffer-CLI.py -e
  ```

  which exports `SysReport/Report.json` and dumps ACPI tables to `SysReport/ACPI/` in one go, plus the optional `-o <dir>` flag and the GUI entry point (`HardwareSniffer.py`).

## Verification

Ran `python3 Hardware-Sniffer-CLI.py -e` on Ubuntu (Python 3.14): all 15 hardware categories collected, report exported, ACPI tables dumped, and the resulting report is accepted by OpCore Simplify.

Closes #54