### PR TITLE
fix(linux): normalize DRM connector types and ACPI paths for report validator

### DIFF
--- a/Scripts/device_locator.py
+++ b/Scripts/device_locator.py
@@ -122,6 +122,8 @@ class LinuxDeviceLocator:
             acpi_path = acpi_path.strip()
             if acpi_path.startswith("\\_SB_."):
                 acpi_path = "\\_SB." + acpi_path[6:]
-            device_location_paths["ACPI Path"] = acpi_path
+                device_location_paths["ACPI Path"] = acpi_path
+            # Only emit ACPI paths under the \_SB scope; OpCore Simplify's
+            # report validator does not accept other scopes (e.g. \_TZ_)
 
         return device_location_paths

--- a/Scripts/platforms/linux.py
+++ b/Scripts/platforms/linux.py
@@ -10,6 +10,16 @@ import os
 PCI_DEVICES_PATH = "/sys/bus/pci/devices"
 USB_DEVICES_PATH = "/sys/bus/usb/devices"
 
+# Kernel DRM connector types (drm_connector_enum) mapped to the connector
+# vocabulary expected by OpCore Simplify's report validator
+DRM_CONNECTOR_TYPE_MAP = {
+    "HDMI-A": "HDMI",
+    "HDMI-B": "HDMI",
+    "DVI-I": "DVI",
+    "DVI-D": "DVI",
+    "DVI-A": "DVI",
+}
+
 class LinuxHardwareInfo:
     def __init__(self, rich_format=True):
         self.lookup_codename = cpu_identifier.CPUIdentifier().lookup_codename
@@ -531,6 +541,7 @@ class LinuxHardwareInfo:
 
                     try:
                         connector_type = "-".join(os.path.basename(os.path.dirname(edid_path)).split("-")[1:-1])
+                        connector_type = DRM_CONNECTOR_TYPE_MAP.get(connector_type, connector_type)
                     except:
                         connector_type = "Uninitialized"
 


### PR DESCRIPTION
## Problem

The Linux platform report (`python3 Hardware-Sniffer-CLI.py -e`) produces values that OpCore Simplify's report validator rejects, blocking the full Linux flow.

Verified on an HP 290 G2 (Coffee Lake, UHD 630, HDMI monitor):

- `Monitor.<name>.Connector Type` = `HDMI-A` — the kernel DRM connector directory is `card0-HDMI-A-1`, and the code kept `HDMI-A` verbatim. The validator only accepts `VGA|DVI|HDMI|LVDS|DP|eDP|Internal|Uninitialized`.
- `System Devices` ACPI paths from the `\_TZ_` scope (e.g. `\_TZ_.FAN0`, `\_TZ_.TZ00`, `\_TZ_.HPTZ`) — the validator only accepts paths under `\_SB`.

## Fix

- `Scripts/platforms/linux.py`: map kernel DRM connector types to the canonical vocabulary (`HDMI-A`/`HDMI-B` → `HDMI`, `DVI-I`/`DVI-D`/`DVI-A` → `DVI`).
- `Scripts/device_locator.py`: only emit an ACPI Path when it resolves under the `\_SB` scope, matching the Windows collector behavior and the validator's accepted scope.

## Verification

Regenerated the report with the patched code and validated against OpCore Simplify's `report_validator.py`:

- Before: `VALID: False` (9 errors)
- After: `VALID: True` (0 errors; 4 tolerated unknown-key warnings)

## Files

| File | Change |
|------|--------|
| `Scripts/platforms/linux.py` | DRM connector type normalization map + use in `monitor()` |
| `Scripts/device_locator.py` | Only emit ACPI Path under `\_SB` scope |
