### PR TITLE
Update star history chart to star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ Distributed under the BSD 3-Clause License. See `LICENSE` for more information.
 
 ## 🌟 **Star History**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lzhoang2801/Hardware-Sniffer&type=Date)](https://star-history.com/#lzhoang2801/Hardware-Sniffer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lzhoang2801/Hardware-Sniffer&type=Date)](https://star-history.dera.page/#lzhoang2801/Hardware-Sniffer&Date)


### PR DESCRIPTION
The current star history chart in the README is broken due to GitHub stargazer API restrictions. This switches it to the `star-history.dera.page` alternative, which uses a different data source that requires no API token and serves both API and frontend from the same domain (no `api.` subdomain anymore). The `/svg` endpoint keeps its existing query parameters.